### PR TITLE
Port LogUtilsExtension from Groovylicious

### DIFF
--- a/Common/src/extension/groovy/io/github/groovymc/cgl/api/extension/StaticGeneralExtensions.groovy
+++ b/Common/src/extension/groovy/io/github/groovymc/cgl/api/extension/StaticGeneralExtensions.groovy
@@ -71,4 +71,20 @@ class StaticGeneralExtensions {
         new ClickEvent(ClickEvent.Action.CHANGE_PAGE, pageNumber.toString())
     }
     // endregion
+
+    // region LogUtils
+    /**
+     * @return An SLF4J logger for the given class
+     */
+    static Logger getLogger(LogUtils self, Class <?> clazz) {
+        return LoggerFactory.getLogger(clazz)
+    }
+
+    /**
+     * @return An SLF4J logger with the given name
+     */
+    static Logger getLogger(LogUtils self, String name) {
+        return LoggerFactory.getLogger(name)
+    }
+    // endregion
 }


### PR DESCRIPTION
Vanilla's `LogUtils.getLogger()` doesn't correctly infer the classname in Groovyland, so these extensions provide a simple alternative.